### PR TITLE
fix(workflow): fix create-crd-update-pr-in-longhorn-repo.yml

### DIFF
--- a/.github/workflows/create-crd-update-pr-in-longhorn-repo.yml
+++ b/.github/workflows/create-crd-update-pr-in-longhorn-repo.yml
@@ -1,13 +1,13 @@
-name: Create CRD Update PR in Longhorn Repo
+name: Create CRD and Manifest Update PR in Longhorn Repo
 
 on:
-  pull_request:
-    types:
-      - closed
+  pull_request_target:
+    branches:
+      - master
+      - "v*"
 
 jobs:
-  if_merged:
-    if: github.event.pull_request.merged == true
+  create-pull-request:
     runs-on: ubuntu-latest
     steps:
     - name: Prepare Packages
@@ -45,7 +45,7 @@ jobs:
         sign-commits: true
         signoff: true
         author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-        committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+        committer: Longhorn GitHub Bot <67932897+longhorn-io-github-bot@users.noreply.github.com>
         commit-message: "chore(crd): update crds.yaml and manifests"
         title: "chore(crd): update crds.yaml and manifests (PR longhorn/longhorn-manager#${{ github.event.pull_request.number}})"
         body: |


### PR DESCRIPTION
- Fix committer for passing DOC check.
- Create PR after opening, editing or synchronizing the longhorn-manager PR.

Longhorn 10193

#### Which issue(s) this PR fixes:
<!--
Use `Issue #<issue number>` or `Issue longhorn/longhorn#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue #

#### What this PR does / why we need it:

#### Special notes for your reviewer:

#### Additional documentation or context
